### PR TITLE
Delete notification_types_node when there are no supported notification types

### DIFF
--- a/applications/zpc/components/zwave_command_classes/src/zwave_command_class_notification.cpp
+++ b/applications/zpc/components/zwave_command_classes/src/zwave_command_class_notification.cpp
@@ -349,6 +349,17 @@ static sl_status_t
     }
   }
 
+  // Delete notification_types_node when there are no supported notification types.
+  if (number_of_supported_notification_types == 0) {
+    sl_status_t status
+     = attribute_store_delete_node(supported_notification_types_node);
+    if (status != SL_STATUS_OK) {
+      sl_log_debug(LOG_TAG, "Failed to remove node %u",
+                   supported_notification_types_node);
+    }
+    return SL_STATUS_OK;
+  }
+
   // Update the notification types reported values in the Attribute Store
   attribute_store_node_t supported_notification_types_node
     = attribute_store_get_first_child_by_type(


### PR DESCRIPTION
## Change

When the notification frame of the command class contains more than two bit masks, the SUPPORTED_NOTIFICATION_TYPES node stays undefined. Consequently, the ZPC (Z-Wave Protocol Controller) makes repeated attempts to retrieve the supported notification type from the device. This continuous loop causes the device to remain in an "Online interviewing" state for an extended period.



#### zwave frame 
71 08 03 00 00 40

#### attribute store 
(350) Supported Notification Types ........................ \<undefined\> (\<\>)

#### Logs 
2023-Nov-28 13:25:19.410614 <d> [attribute_resolver] Attribute ID 83 needs a Get
2023-Nov-28 13:25:19.411275 <d> [attribute_resolver] Retransmitting Get command for Attribute ID 83 (attempt 4 out of 5)

2023-Nov-28 13:25:22.265804 <d> [zwave_command_handler_callbacks] Dispatching incoming command (encapsulation 3) from NodeID 5:0 - [ 71 08 03 00 00 40 ]
2023-Nov-28 13:25:22.266390 <d> [zwave_command_class_notification] Supported notification types Bit Masks length is wrong


2023-Nov-28 13:25:30.952589 <d> [attribute_resolver] Attribute ID 83 needs a Get
2023-Nov-28 13:25:30.953289 <d> [attribute_resolver] Retransmitting Get command for Attribute ID 83 (attempt 5 out of 5)

2023-Nov-28 13:25:33.824015 <d> [zwave_command_handler_callbacks] Dispatching incoming command (encapsulation 3) from NodeID 5:0 - [ 71 08 03 00 00 40 ]
2023-Nov-28 13:25:33.824700 <d> [zwave_command_class_notification] Supported notification types Bit Masks length is wrong


## Checklist


- [x] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


